### PR TITLE
ci: automate releases on version tags

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,61 @@
+# Cut a GitHub Release when you push a version tag (e.g. `git tag v1.4.1 && git push --tags`).
+#
+# It pulls the matching section out of CHANGELOG.md for the release notes, builds the Release VSIX,
+# and attaches it. The VSIX build is best-effort (`continue-on-error`) because building a VSIX on a
+# hosted runner is finicky and version-sensitive - if it doesn't produce an artifact, the release is
+# still created with notes and you can drag-drop your local Release build onto it (one upload).
+#
+# The release notes come straight from CHANGELOG.md, so the only per-release work is: add a
+# `## <version> - <date>` section to the changelog, then tag. No more per-feature posting.
+name: Release
+
+on:
+  push:
+    tags:
+      - 'v*'
+
+permissions:
+  contents: write   # create releases + upload assets
+
+jobs:
+  release:
+    runs-on: windows-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Extract release notes from CHANGELOG
+        id: notes
+        shell: pwsh
+        run: |
+          $version = "${{ github.ref_name }}".TrimStart('v')   # v1.4.1 -> 1.4.1
+          $body = @()
+          $inSection = $false
+          foreach ($line in (Get-Content CHANGELOG.md)) {
+            if ($line -match "^##\s+$([regex]::Escape($version))(\s|$)") { $inSection = $true; continue }
+            elseif ($inSection -and $line -match '^##\s') { break }
+            elseif ($inSection) { $body += $line }
+          }
+          if (-not $body) { $body = @("Release $version. See CHANGELOG.md.") }
+          ($body -join "`n").Trim() | Set-Content -Encoding utf8 release-notes.md
+          Write-Host "--- notes ---"; Get-Content release-notes.md
+
+      - name: Setup MSBuild
+        uses: microsoft/setup-msbuild@v2
+
+      - name: Build Release VSIX (best-effort)
+        id: build
+        continue-on-error: true
+        shell: pwsh
+        run: |
+          msbuild src/ClaudeCodeVS/ClaudeCodeVS.csproj /t:Restore,Build /p:Configuration=Release /p:DeployExtension=false /v:minimal /nologo
+          $vsix = "src/ClaudeCodeVS/bin/Release/ClaudeCodeVS.vsix"
+          if (Test-Path $vsix) { "vsix=$vsix" >> $env:GITHUB_OUTPUT } else { Write-Host "::warning::VSIX build produced no artifact - releasing notes only." }
+
+      - name: Create GitHub Release
+        uses: softprops/action-gh-release@v2
+        with:
+          name: ${{ github.ref_name }}
+          body_path: release-notes.md
+          files: ${{ steps.build.outputs.vsix }}
+          fail_on_unmatched_files: false
+          make_latest: true


### PR DESCRIPTION
Adds `.github/workflows/release.yml`. On a `v*` tag push it pulls that version's section from `CHANGELOG.md` for the release notes, builds the Release VSIX, and cuts the GitHub Release with the VSIX attached.

The VSIX-build step is `continue-on-error` — building a VSIX on a hosted runner is finicky and version-sensitive, so if it doesn't produce an artifact on the first tag, **the release is still created with notes** and you upload your local Release build (one drag-drop), then we tune the runner/MSBuild. The notes-from-CHANGELOG + release-creation parts are reliable.

After this merges, shipping a release is:
1. Add a `## <version> - <date>` section to `CHANGELOG.md`.
2. `git tag vX.Y.Z && git push --tags`.

No more per-feature posting — one tag per release does the announcement.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
