### PR TITLE
fix: AmbiguousMatchException in native terminal launch on updated VS builds (1.14.1, #12)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Changelog
 
+## 1.14.1 - 2026-07-29
+
+### Fixes
+
+- **Native terminal launch failed with `AmbiguousMatchException` on updated VS builds** ([#12](https://github.com/firish/claude_code_vs/issues/12) — VS 2022 and VS 2026, falling back to the external console). The launcher addressed undocumented Terminal/ServiceHub members with bare `Type.GetMethod(name)`, which *throws* the moment a servicing update adds an overload of that member — and the identical failure on both VS versions points at `IServiceBroker.GetProxyAsync`, whose assembly ships to both. All four by-name lookups (`GetProxyAsync`, `CreateTerminalWindowAsync`, `Add/RemoveCachedProfile`) now enumerate overloads and select by the exact call shape — `CreateTerminalWindowAsync` additionally tolerates either parameter order — so a richer overload added by a future VS update can never break the launch again. Side-by-side VS 2022 + 2026 installs were not the cause.
+
 ## 1.14.0 - 2026-07-28
 
 **Screen capture — giving Claude eyes** ([`docs/VISION.md`](docs/VISION.md)). Two new `vs-debug` tools let Claude take its own screenshots instead of asking you to paste one: `vs_capture_window` (the debugged app's window; the VS window; or any window by title — the browser showing your site) and `vs_capture_screen` (one monitor or all). Gated behind a new **Allow screen capture** panel toggle — default off, in-memory, resets each session, and it gates *every* target, since a title-addressed capture can already see anything on the desktop.

--- a/src/ClaudeCodeVS/Terminal/VsTerminalLauncher.cs
+++ b/src/ClaudeCodeVS/Terminal/VsTerminalLauncher.cs
@@ -94,8 +94,26 @@ internal static class VsTerminalLauncher
             }
             IServiceBroker broker = container.GetFullAccessServiceBroker();
 
-            // T = ITerminalService is only known as a reflected Type, so the generic call needs MakeGenericMethod.
-            var getProxy = typeof(IServiceBroker).GetMethod("GetProxyAsync")!.MakeGenericMethod(terminalServiceType);
+            // T = ITerminalService is only known as a reflected Type, so the generic call needs
+            // MakeGenericMethod. Overload-tolerant lookup: a bare GetMethod("GetProxyAsync") throws
+            // AmbiguousMatchException the moment a ServiceHub.Framework servicing update adds an
+            // overload - issue #12, seen on VS2022 AND VS2026 (the assembly ships to both). Select the
+            // exact shape we call instead.
+            var getProxyOpen = PickMethod(typeof(IServiceBroker), "GetProxyAsync", m =>
+            {
+                if (!m.IsGenericMethodDefinition) return false;
+                var p = m.GetParameters();
+                return p.Length == 3
+                    && typeof(ServiceRpcDescriptor).IsAssignableFrom(p[0].ParameterType)
+                    && p[1].ParameterType == typeof(ServiceActivationOptions)
+                    && p[2].ParameterType == typeof(CancellationToken);
+            });
+            if (getProxyOpen == null)
+            {
+                Log.Warn("Native VS terminal: no compatible IServiceBroker.GetProxyAsync overload - falling back to external console.");
+                return false;
+            }
+            var getProxy = getProxyOpen.MakeGenericMethod(terminalServiceType);
             object? terminalService = await UnwrapAsync(
                 getProxy.Invoke(broker, new object?[] { descriptor, default(ServiceActivationOptions), ct }));
             if (terminalService == null)
@@ -123,7 +141,8 @@ internal static class VsTerminalLauncher
 
                 // TerminalWindowOptions.Profile alone is ignored unless the profile is first registered with the
                 // service - without this, CreateTerminalWindowAsync silently falls back to the user's default shell.
-                terminalServiceType.GetMethod("AddCachedProfile")?.Invoke(terminalService, new object?[] { profile });
+                PickMethod(terminalServiceType, "AddCachedProfile", m => m.GetParameters().Length == 1)?
+                    .Invoke(terminalService, new object?[] { profile });
 
                 object options = Activator.CreateInstance(windowOptionsType)!; // ctor already defaults Focus/AllowUserInput/AutoResize=true
                 windowOptionsType.GetProperty("Name")?.SetValue(options, "Claude Code");
@@ -132,8 +151,24 @@ internal static class VsTerminalLauncher
                 windowOptionsType.GetProperty("Focus")?.SetValue(options, true);
                 windowOptionsType.GetProperty("AllowUserInput")?.SetValue(options, true);
 
-                object? guidResult = await UnwrapAsync(
-                    terminalServiceType.GetMethod("CreateTerminalWindowAsync")!.Invoke(terminalService, new object?[] { ct, options }));
+                // Same overload tolerance as GetProxyAsync, plus parameter-ORDER tolerance: pick the
+                // 2-arg overload taking (options, token) in either order and build the call to match.
+                var create = PickMethod(terminalServiceType, "CreateTerminalWindowAsync", m =>
+                {
+                    var p = m.GetParameters();
+                    return p.Length == 2
+                        && p.Any(x => x.ParameterType == typeof(CancellationToken))
+                        && p.Any(x => x.ParameterType.IsAssignableFrom(windowOptionsType));
+                });
+                if (create == null)
+                {
+                    Log.Warn("Native VS terminal: no compatible CreateTerminalWindowAsync overload - falling back to external console.");
+                    return false;
+                }
+                object?[] callArgs = create.GetParameters()[0].ParameterType == typeof(CancellationToken)
+                    ? new object?[] { ct, options }
+                    : new object?[] { options, ct };
+                object? guidResult = await UnwrapAsync(create.Invoke(terminalService, callArgs));
                 if (guidResult is not Guid)
                 {
                     Log.Warn("Native VS terminal: CreateTerminalWindowAsync returned no guid - falling back to external console.");
@@ -151,7 +186,8 @@ internal static class VsTerminalLauncher
                 try
                 {
                     if (profile != null)
-                        terminalServiceType.GetMethod("RemoveCachedProfile")?.Invoke(terminalService, new object?[] { profile });
+                        PickMethod(terminalServiceType, "RemoveCachedProfile", m => m.GetParameters().Length == 1)?
+                            .Invoke(terminalService, new object?[] { profile });
                 }
                 catch { /* best-effort cleanup; the profile cache is cosmetic */ }
 
@@ -164,6 +200,22 @@ internal static class VsTerminalLauncher
             Log.Warn($"Native VS terminal launch failed ({e.GetType().Name}: {e.Message}) - falling back to external console.");
             return false;
         }
+    }
+
+    /// <summary>
+    /// Overload-tolerant method lookup. Type.GetMethod(name) THROWS AmbiguousMatchException the moment
+    /// a VS/ServiceHub update adds an overload of a member we address by name (issue #12) - and this
+    /// whole class talks to assemblies that update underneath us. Enumerate by name, filter by the
+    /// call shape we intend, and among survivors prefer the fewest parameters, so a richer overload
+    /// added later never breaks the existing call.
+    /// </summary>
+    private static MethodInfo? PickMethod(Type type, string name, Func<MethodInfo, bool>? where = null)
+    {
+        IEnumerable<MethodInfo> candidates = type
+            .GetMethods(BindingFlags.Public | BindingFlags.Instance | BindingFlags.Static)
+            .Where(m => m.Name == name);
+        if (where != null) candidates = candidates.Where(where);
+        return candidates.OrderBy(m => m.GetParameters().Length).FirstOrDefault();
     }
 
     // ---------------- reflection plumbing (mirrors Testing/TestRunner.cs) ----------------

--- a/src/ClaudeCodeVS/source.extension.vsixmanifest
+++ b/src/ClaudeCodeVS/source.extension.vsixmanifest
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="utf-8"?>
 <PackageManifest Version="2.0.0" xmlns="http://schemas.microsoft.com/developer/vsx-schema/2011" xmlns:d="http://schemas.microsoft.com/developer/vsx-schema-design/2011">
   <Metadata>
-    <Identity Id="ClaudeCodeVS.d9032717-8a83-4ab5-9b63-2fe9d9a78481" Version="1.14.0" Language="en-US" Publisher="Rishi Gulati" />
+    <Identity Id="ClaudeCodeVS.d9032717-8a83-4ab5-9b63-2fe9d9a78481" Version="1.14.1" Language="en-US" Publisher="Rishi Gulati" />
     <DisplayName>Claude Code for Visual Studio</DisplayName>
     <Description xml:space="preserve">Bring Claude Code into Visual Studio: a native diff window with accept/reject (and reject-with-feedback), automatic selection and C#/C++ compiler-diagnostics context, live debugger access (Claude reads your runtime state and can opt-in drive the debugger), Roslyn code navigation with decompile, a test runner that catches flaky tests under the debugger, finished/needs-input notifications, and a token/cost panel. The claude CLI does the agent work; this extension is the IDE half of Claude Code's integration protocol. Requires the Claude Code CLI. Unofficial, not affiliated with Anthropic.</Description>
     <MoreInfo>https://github.com/firish/claude_code_vs</MoreInfo>


### PR DESCRIPTION
## Fix #12: `AmbiguousMatchException` in the native terminal launch (1.14.1)

`Type.GetMethod(name)` **throws** `AmbiguousMatchException` when the type has more than one overload of that name — and `VsTerminalLauncher` used bare by-name lookups against assemblies that update underneath us (`Microsoft.VisualStudio.Terminal.dll`, `Microsoft.ServiceHub.Framework`). A servicing update added an overload somewhere in that chain and the whole launch threw before reaching the terminal, dropping every launch to the external-console fallback (which worked as designed — this was degraded, not broken).

The reporter seeing the identical failure on **both VS 2022 and VS 2026** points at `IServiceBroker.GetProxyAsync` — ServiceHub.Framework ships to both VS versions via servicing — but all four by-name lookups had the same latent bug, so all four are fixed:

- New `PickMethod(type, name, shapeFilter)`: enumerate overloads by name, filter by the exact call shape, prefer the fewest parameters among survivors — a richer overload added by a future VS update can never break the existing call again.
- `GetProxyAsync`: selected by generic definition + `(ServiceRpcDescriptor, ServiceActivationOptions, CancellationToken)`.
- `CreateTerminalWindowAsync`: selected by shape **and** tolerant of either `(options, ct)` parameter order — the argument array is built to match the chosen overload.
- `Add`/`RemoveCachedProfile`: selected by single-parameter shape.
- A missing-compatible-overload case now logs *which member* and falls back cleanly, so the next drift report is a one-glance diagnosis.

Answers the reporter's question: side-by-side VS 2022 + 2026 was **not** the cause — each VS loads its own copy of everything; the trigger is the servicing version of the reflected assemblies.

Version bumped to 1.14.1 with a CHANGELOG entry. Builds clean; the fallback path is unchanged, so worst case remains exactly today's behavior (external console).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
