### PR TITLE
fix: docked terminal on VS 2022 via the 17.x legacy CreateTerminalAsync surface (1.14.2, #12)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Changelog
 
+## 1.14.2 - 2026-07-30
+
+### Fixes
+
+- **The docked terminal now works on VS 2022** ([#12](https://github.com/firish/claude_code_vs/issues/12) follow-up: 1.14.1 fixed VS 2026 but VS 2022 fell back with "Terminal types not found"). Root cause, established by dumping 17.14's `Microsoft.VisualStudio.Terminal.dll` headlessly: VS 2022 ships the same brokered terminal service with an **older contract** — no `TerminalWindowOptions`, no `CreateTerminalWindowAsync`. The launcher now detects which surface is present and, on 17.x, calls the legacy `CreateTerminalAsync(ct, name, ProfileConfig, workingDirectory)` (same `ProfileConfig` ctor on both) with a best-effort `ShowAsync` for focus parity. The launch log names which surface was used. The external-console fallback is unchanged for anything older or stranger.
+
 ## 1.14.1 - 2026-07-29
 
 ### Fixes

--- a/src/ClaudeCodeVS/Terminal/VsTerminalLauncher.cs
+++ b/src/ClaudeCodeVS/Terminal/VsTerminalLauncher.cs
@@ -70,11 +70,14 @@ internal static class VsTerminalLauncher
             var descriptorsType = FindType("Microsoft.VisualStudio.Terminal.TerminalServiceDescriptors");
             var windowOptionsType = FindType("Microsoft.VisualStudio.Terminal.TerminalWindowOptions");
             var profileConfigType = FindType("Microsoft.VisualStudio.Terminal.ProfileConfig");
-            if (terminalServiceType == null || descriptorsType == null || windowOptionsType == null || profileConfigType == null)
+            if (terminalServiceType == null || descriptorsType == null || profileConfigType == null)
             {
                 Log.Warn("Native VS terminal: Microsoft.VisualStudio.Terminal types not found (VS edition/version mismatch) - falling back to external console.");
                 return false;
             }
+            // TerminalWindowOptions only exists on the 18.x (VS 2026) surface. Its absence means the
+            // VS 2022 (17.x) contract, where CreateTerminalAsync takes name/profile/cwd as plain args
+            // (issue #12 follow-up: same service, older shape - dumped headlessly from 17.14's DLL).
 
             var descriptor = descriptorsType
                 .GetProperty("TerminalServiceDescriptor", BindingFlags.Public | BindingFlags.Static)?
@@ -144,38 +147,74 @@ internal static class VsTerminalLauncher
                 PickMethod(terminalServiceType, "AddCachedProfile", m => m.GetParameters().Length == 1)?
                     .Invoke(terminalService, new object?[] { profile });
 
-                object options = Activator.CreateInstance(windowOptionsType)!; // ctor already defaults Focus/AllowUserInput/AutoResize=true
-                windowOptionsType.GetProperty("Name")?.SetValue(options, "Claude Code");
-                windowOptionsType.GetProperty("WorkingDirectory")?.SetValue(options, workingDirectory);
-                windowOptionsType.GetProperty("Profile")?.SetValue(options, profile);
-                windowOptionsType.GetProperty("Focus")?.SetValue(options, true);
-                windowOptionsType.GetProperty("AllowUserInput")?.SetValue(options, true);
-
                 // Same overload tolerance as GetProxyAsync, plus parameter-ORDER tolerance: pick the
                 // 2-arg overload taking (options, token) in either order and build the call to match.
-                var create = PickMethod(terminalServiceType, "CreateTerminalWindowAsync", m =>
+                var create = windowOptionsType == null ? null : PickMethod(terminalServiceType, "CreateTerminalWindowAsync", m =>
                 {
                     var p = m.GetParameters();
                     return p.Length == 2
                         && p.Any(x => x.ParameterType == typeof(CancellationToken))
                         && p.Any(x => x.ParameterType.IsAssignableFrom(windowOptionsType));
                 });
-                if (create == null)
+
+                object? guidResult;
+                string surface;
+                if (create != null)
                 {
-                    Log.Warn("Native VS terminal: no compatible CreateTerminalWindowAsync overload - falling back to external console.");
-                    return false;
+                    object options = Activator.CreateInstance(windowOptionsType!)!; // ctor already defaults Focus/AllowUserInput/AutoResize=true
+                    windowOptionsType!.GetProperty("Name")?.SetValue(options, "Claude Code");
+                    windowOptionsType.GetProperty("WorkingDirectory")?.SetValue(options, workingDirectory);
+                    windowOptionsType.GetProperty("Profile")?.SetValue(options, profile);
+                    windowOptionsType.GetProperty("Focus")?.SetValue(options, true);
+                    windowOptionsType.GetProperty("AllowUserInput")?.SetValue(options, true);
+
+                    object?[] callArgs = create.GetParameters()[0].ParameterType == typeof(CancellationToken)
+                        ? new object?[] { ct, options }
+                        : new object?[] { options, ct };
+                    guidResult = await UnwrapAsync(create.Invoke(terminalService, callArgs));
+                    surface = "18.x surface";
                 }
-                object?[] callArgs = create.GetParameters()[0].ParameterType == typeof(CancellationToken)
-                    ? new object?[] { ct, options }
-                    : new object?[] { options, ct };
-                object? guidResult = await UnwrapAsync(create.Invoke(terminalService, callArgs));
+                else
+                {
+                    // VS 2022 (17.x) legacy surface: CreateTerminalAsync(ct, name, ProfileConfig, cwd).
+                    // Prefer the exact-ProfileConfig overload over its ITerminalProfile twin.
+                    var createLegacy = PickMethod(terminalServiceType, "CreateTerminalAsync", m =>
+                    {
+                        var p = m.GetParameters();
+                        return p.Length == 4
+                            && p[0].ParameterType == typeof(CancellationToken)
+                            && p[1].ParameterType == typeof(string)
+                            && p[2].ParameterType == profileConfigType
+                            && p[3].ParameterType == typeof(string);
+                    });
+                    if (createLegacy == null)
+                    {
+                        Log.Warn("Native VS terminal: neither CreateTerminalWindowAsync (18.x) nor a compatible CreateTerminalAsync (17.x) found - falling back to external console.");
+                        return false;
+                    }
+                    guidResult = await UnwrapAsync(createLegacy.Invoke(terminalService, new object?[] { ct, "Claude Code", profile, workingDirectory }));
+                    surface = "17.x legacy surface";
+
+                    // The old surface has no Focus option; ShowAsync is its bring-to-front. Best-effort.
+                    if (guidResult is Guid g)
+                    {
+                        try
+                        {
+                            await UnwrapAsync(PickMethod(terminalServiceType, "ShowAsync",
+                                    m => m.GetParameters().Length == 2 && m.GetParameters()[0].ParameterType == typeof(Guid))?
+                                .Invoke(terminalService, new object?[] { g, ct }));
+                        }
+                        catch { /* focus is cosmetic */ }
+                    }
+                }
+
                 if (guidResult is not Guid)
                 {
-                    Log.Warn("Native VS terminal: CreateTerminalWindowAsync returned no guid - falling back to external console.");
+                    Log.Warn("Native VS terminal: terminal creation returned no guid - falling back to external console.");
                     return false;
                 }
 
-                Log.Info($"Launched Claude Code in VS's native Terminal window (port {ssePort}, cwd '{workingDirectory ?? "(default)"}').");
+                Log.Info($"Launched Claude Code in VS's native Terminal window ({surface}, port {ssePort}, cwd '{workingDirectory ?? "(default)"}').");
                 return true;
             }
             finally

--- a/src/ClaudeCodeVS/source.extension.vsixmanifest
+++ b/src/ClaudeCodeVS/source.extension.vsixmanifest
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="utf-8"?>
 <PackageManifest Version="2.0.0" xmlns="http://schemas.microsoft.com/developer/vsx-schema/2011" xmlns:d="http://schemas.microsoft.com/developer/vsx-schema-design/2011">
   <Metadata>
-    <Identity Id="ClaudeCodeVS.d9032717-8a83-4ab5-9b63-2fe9d9a78481" Version="1.14.1" Language="en-US" Publisher="Rishi Gulati" />
+    <Identity Id="ClaudeCodeVS.d9032717-8a83-4ab5-9b63-2fe9d9a78481" Version="1.14.2" Language="en-US" Publisher="Rishi Gulati" />
     <DisplayName>Claude Code for Visual Studio</DisplayName>
     <Description xml:space="preserve">Bring Claude Code into Visual Studio: a native diff window with accept/reject (and reject-with-feedback), automatic selection and C#/C++ compiler-diagnostics context, live debugger access (Claude reads your runtime state and can opt-in drive the debugger), Roslyn code navigation with decompile, a test runner that catches flaky tests under the debugger, finished/needs-input notifications, and a token/cost panel. The claude CLI does the agent work; this extension is the IDE half of Claude Code's integration protocol. Requires the Claude Code CLI. Unofficial, not affiliated with Anthropic.</Description>
     <MoreInfo>https://github.com/firish/claude_code_vs</MoreInfo>


### PR DESCRIPTION
## Fix #12 follow-up: docked terminal on VS 2022 via the 17.x legacy surface (1.14.2)

1.14.1 fixed the `AmbiguousMatchException` (confirmed by the reporter on VS 2026), but VS 2022 still fell back with *"Microsoft.VisualStudio.Terminal types not found"*. Debugged locally against VS 2022 Community 17.14: the assembly and brokered service **exist** on 2022 — the contract is just an older generation. A headless `MetadataLoadContext` dump of 17.14's `Microsoft.VisualStudio.Terminal.dll` shows no `TerminalWindowOptions` and no `CreateTerminalWindowAsync`; instead the 17.x surface is:

```
Task<Guid> CreateTerminalAsync(CancellationToken, string name, ProfileConfig profile, string workingDirectory)
```

with the **same 4-arg `ProfileConfig` ctor** we already build, `AddCachedProfile(ITerminalProfile)` (which `ProfileConfig` implements), and `ShowAsync(guid)` as the bring-to-front.

### Change

- `TerminalWindowOptions` is now optional: present → the 18.x `CreateTerminalWindowAsync` path exactly as before; absent → the legacy `CreateTerminalAsync` (exact-`ProfileConfig` overload preferred over its `ITerminalProfile` twin) + best-effort `ShowAsync` for focus parity.
- The success log names which surface launched (`18.x surface` / `17.x legacy surface`), so the next contract-drift report is a one-glance diagnosis.
- Fallback behavior for anything older or stranger is unchanged: clean external console.

### Verification status

Root cause is established against the real 17.14 contract dump (in-repo scratch inspector, per the CLAUDE.md internal-API workflow); VS 2026 path is unchanged code. Live click-verification on VS 2022 is pending — the issue reporter (17.14.35 Professional) is the confirmation loop, same as 1.14.1.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
