### PR TITLE
feat: experimental ARM64 support (1.14.3)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,13 @@
 # Changelog
 
+## 1.14.3 - 2026-07-31
+
+**Experimental ARM64 support** — the extension now installs on ARM64 Visual Studio (Windows on ARM: Surface devices, Parallels on Apple silicon). Requested via the Marketplace Q&A.
+
+- The extension is managed/AnyCPU and every reflected VS surface (Roslyn, Test Explorer, the terminal service) binds to the host's own copies, so the core — diff gate, diagnostics, semantic navigation, tests, debugger reads/drive, attachments, screen capture, notifications — runs natively on ARM64 devenv. The enabling change is a second `arm64` installation target in the manifest.
+- **Two x64-only pieces now refuse with clear messages on ARM64 instead of failing confusingly:** the six ClrMD tools (`vs_wait_chains`, `vs_async_stacks`, `vs_heap_stats`, `vs_threadpool`, `vs_gc_roots`, `vs_heap_diff` — the bundled worker is x64 and ClrMD must match the debuggee's architecture) and `vs_set_data_breakpoint` (managed data breakpoints are an x64-only .NET runtime/debugger capability).
+- "Experimental" means exactly this: architecture-neutral by construction, verified in-house on x64 only — ARM64 confirmation is community-sourced. Reports welcome on the tracker.
+
 ## 1.14.2 - 2026-07-30
 
 ### Fixes

--- a/README.md
+++ b/README.md
@@ -192,6 +192,7 @@ For debugger access it adds a `UserPromptSubmit` hook that injects live break st
 - Cost figures are estimates, not billing.
 - Attachments: images read directly must be PNG/JPEG/GIF/WebP under 5 MB (bigger ones attach with a downscale note; BMPs are transcoded). Excel, video, archives and other binaries attach as paths for Claude's tools rather than direct reads. Attachment token figures are estimates.
 - Screen capture is opt-in per session and cannot capture minimized windows (the tool asks for a restore). Windows that block `PrintWindow` fall back to a screen-region copy, which includes anything overlapping them. See [`docs/VISION.md`](docs/VISION.md).
+- ARM64 Windows (Surface devices, Parallels on Apple silicon) is **experimental** as of 1.14.3: the core surface is architecture-neutral and runs natively, but it is community-verified rather than tested in-house. The ClrMD memory/deadlock tools and managed data breakpoints are x64-only and say so when called.
 
 ## Troubleshooting
 

--- a/docs/marketplace.md
+++ b/docs/marketplace.md
@@ -158,6 +158,7 @@ This is a protocol bridge, not a re-implementation of the agent. On Launch it st
 - Cost figures are estimates, not billing.
 - Attachments: images read directly must be PNG/JPEG/GIF/WebP under 5 MB (bigger ones attach with a downscale note; BMPs are transcoded). Excel, video, archives and other binaries attach as paths for Claude's tools rather than direct reads. Attachment token figures are estimates.
 - Screen capture is opt-in per session and cannot capture minimized windows (the tool asks for a restore). Windows that block `PrintWindow` fall back to a screen-region copy, which includes anything overlapping them.
+- ARM64 Windows (Surface devices, Parallels on Apple silicon) is **experimental** as of 1.14.3: the core surface is architecture-neutral and runs natively, but it is community-verified rather than tested in-house. The ClrMD memory/deadlock tools and managed data breakpoints are x64-only and say so when called.
 
 ## Troubleshooting
 

--- a/src/ClaudeCodeVS/Debugging/ClrMdReader.cs
+++ b/src/ClaudeCodeVS/Debugging/ClrMdReader.cs
@@ -35,6 +35,16 @@ internal static class ClrMdReader
 
     private static JObject RunWorker(string command, int pid, params string[] extra)
     {
+        // Experimental ARM64 host support (1.14.3): the bundled worker is x64, and ClrMD must match the
+        // debuggee's architecture - on ARM64 Windows the debuggee is native ARM64 while the worker would
+        // run emulated x64, so the snapshot fails confusingly. Refuse honestly instead.
+        if (System.Runtime.InteropServices.RuntimeInformation.OSArchitecture == System.Runtime.InteropServices.Architecture.Arm64)
+            return new JObject
+            {
+                ["error"] = "this tool is x64-only for now: the bundled ClrMD worker cannot snapshot an ARM64 process. "
+                          + "Every non-ClrMD debugger tool (state, evaluate, threads, breakpoints, stepping, attach, ...) works on ARM64.",
+            };
+
         string dir = Path.GetDirectoryName(typeof(ClrMdReader).Assembly.Location) ?? "";
         string exe = Path.Combine(dir, "ClrMdWorker", "ClrMdWorker.exe");
         if (!File.Exists(exe))

--- a/src/ClaudeCodeVS/Tools/DataBpTools.cs
+++ b/src/ClaudeCodeVS/Tools/DataBpTools.cs
@@ -42,6 +42,11 @@ internal sealed class VsSetDataBreakpointTool : IIdeTool
 
     public async Task<object> InvokeAsync(JToken args, CancellationToken ct)
     {
+        // Experimental ARM64 host support (1.14.3): managed data breakpoints are an x64-only capability
+        // of the .NET runtime/debugger itself - not something this extension can port around.
+        if (System.Runtime.InteropServices.RuntimeInformation.OSArchitecture == System.Runtime.InteropServices.Architecture.Arm64)
+            return new JObject { ["error"] = "managed data breakpoints are x64-only (a .NET runtime/debugger limitation) - unavailable on ARM64. Use vs_set_breakpoint with a condition as the nearest substitute." };
+
         if (!Ui.BridgeStatus.AllowDebuggerDrive)
             return new JObject
             {

--- a/src/ClaudeCodeVS/source.extension.vsixmanifest
+++ b/src/ClaudeCodeVS/source.extension.vsixmanifest
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="utf-8"?>
 <PackageManifest Version="2.0.0" xmlns="http://schemas.microsoft.com/developer/vsx-schema/2011" xmlns:d="http://schemas.microsoft.com/developer/vsx-schema-design/2011">
   <Metadata>
-    <Identity Id="ClaudeCodeVS.d9032717-8a83-4ab5-9b63-2fe9d9a78481" Version="1.14.2" Language="en-US" Publisher="Rishi Gulati" />
+    <Identity Id="ClaudeCodeVS.d9032717-8a83-4ab5-9b63-2fe9d9a78481" Version="1.14.3" Language="en-US" Publisher="Rishi Gulati" />
     <DisplayName>Claude Code for Visual Studio</DisplayName>
     <Description xml:space="preserve">Bring Claude Code into Visual Studio: a native diff window with accept/reject (and reject-with-feedback), automatic selection and C#/C++ compiler-diagnostics context, live debugger access (Claude reads your runtime state and can opt-in drive the debugger), Roslyn code navigation with decompile, a test runner that catches flaky tests under the debugger, finished/needs-input notifications, and a token/cost panel. The claude CLI does the agent work; this extension is the IDE half of Claude Code's integration protocol. Requires the Claude Code CLI. Unofficial, not affiliated with Anthropic.</Description>
     <MoreInfo>https://github.com/firish/claude_code_vs</MoreInfo>
@@ -13,6 +13,12 @@
   <Installation>
     <InstallationTarget Id="Microsoft.VisualStudio.Community" Version="[17.14,19.0)">
       <ProductArchitecture>amd64</ProductArchitecture>
+    </InstallationTarget>
+    <!-- Experimental (1.14.3): the extension is managed/AnyCPU and the reflected VS surfaces are the
+         host's own, so ARM64 devenv runs it natively. x64-only pieces (the bundled ClrMD worker, managed
+         data breakpoints) refuse with clear messages at runtime rather than failing confusingly. -->
+    <InstallationTarget Id="Microsoft.VisualStudio.Community" Version="[17.14,19.0)">
+      <ProductArchitecture>arm64</ProductArchitecture>
     </InstallationTarget>
   </Installation>
   <Dependencies>


### PR DESCRIPTION
﻿feat: experimental ARM64 support (1.14.3)

Requested via Marketplace Q&A (Windows on ARM: Surface devices, Parallels on
Apple silicon). The extension is managed/AnyCPU and every reflected VS surface
(Roslyn, Test Explorer, terminal service) binds to the host's own copies, so
the core - diff gate, diagnostics, semantic navigation, tests, debugger
reads/drive, attachments, screen capture, notifications - runs natively on
ARM64 devenv. The enabling change is a second arm64 InstallationTarget.

The two x64-only pieces refuse with clear messages on ARM64 instead of failing
confusingly:
- the six ClrMD tools (gated at the RunWorker funnel): the bundled worker is
  x64 and ClrMD must match the debuggee's architecture - on ARM64 the debuggee
  is native ARM64, so the snapshot can never work as shipped;
- vs_set_data_breakpoint: managed data breakpoints are an x64-only capability
  of the .NET runtime/debugger itself (the error suggests conditional
  breakpoints as the nearest substitute).

Experimental = architecture-neutral by construction, verified in-house on x64
only; ARM64 confirmation is community-sourced (README/marketplace limitation
lines say so).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

