### PR TITLE
fix: marketplace-review fixes - selective edit gate, hook resilience, docs discoverability (1.14.4)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,15 @@
 # Changelog
 
+## 1.14.4 - 2026-07-31
+
+Three fixes straight from Marketplace feedback.
+
+### Fixes
+
+- **Sessions no longer stall on Claude's own scratch/memory writes.** The diff gate now skips the CLI's working files - the `~/.claude` memory/config tree, temp-dir scratch files, and the workspace's `.claude/` internals - each skip visible in the activity feed. Project code is unchanged: every create or edit under the workspace still opens the diff. (Reported as "Accept/Reject when creating scratch/temporary files halts the session".)
+- **No more "-File does not exist" hook errors.** Two halves: hook/MCP scripts now install whenever a CLI session *connects* to the bridge (not only via the Launch button - covers manual `claude` + `/ide` and fresh clones whose committed `settings.json` references our hooks), and registered hook commands are now `Test-Path`-guarded so a genuinely missing script is a silent no-op instead of a per-prompt error. Existing settings.json entries are migrated to the guarded form in place.
+- **Docs now open with where the extension lives** (**View > Other Windows > Claude Code**) - it was documented but buried.
+
 ## 1.14.3 - 2026-07-31
 
 **Experimental ARM64 support** — the extension now installs on ARM64 Visual Studio (Windows on ARM: Surface devices, Parallels on Apple silicon). Requested via the Marketplace Q&A.

--- a/README.md
+++ b/README.md
@@ -142,6 +142,8 @@ A dockable Claude Code panel shows connection status, edit decisions, and token 
 - **Marketplace:** search for *Claude Code for Visual Studio* in **Extensions > Manage Extensions**, or install from the [Visual Studio Marketplace](https://marketplace.visualstudio.com/items?itemName=firish.bridgev1).
 - **Sideload:** download the `.vsix` from [Releases](https://github.com/firish/claude_code_vs/releases) and double-click it.
 
+After installing, everything lives in one dockable panel: **View > Other Windows > Claude Code**.
+
 ## Quickstart
 
 1. Open your project or solution in Visual Studio 2026.

--- a/docs/GETTING-STARTED.md
+++ b/docs/GETTING-STARTED.md
@@ -1,5 +1,7 @@
 # Getting started
 
+**Where is everything?** One dockable panel: **View > Other Windows > Claude Code**. Open it, click **Launch Claude Code**, and you are running - everything else in this guide starts from that panel. (The launch command is also on the **Tools** menu.)
+
 The practical setup: install the extension, launch Claude connected to Visual Studio, and learn the panel and the safety toggles. For what the tools actually do once you are connected, see [`DEBUGGER.md`](DEBUGGER.md), [`TESTING.md`](TESTING.md), [`SEMANTIC.md`](SEMANTIC.md), and [`VISION.md`](VISION.md).
 
 **Jump to:** [Requirements](#requirements) · [Install](#install) · [First launch](#first-launch) · [The panel](#the-panel) · [The diff gate](#the-diff-gate) · [Auto-accept](#run-wild-auto-accept) · [Attachments](#attachments-screenshots-and-files) · [Notifications](#notifications) · [Let Claude debug](#letting-claude-debug) · [Troubleshooting](#troubleshooting)
@@ -55,6 +57,8 @@ It shows:
 Every edit Claude proposes opens in Visual Studio's own diff viewer, and approving there is the only step. There is no second yes/no prompt in the terminal.
 
 ![A Claude edit in the Visual Studio diff viewer, with Accept, Reject, and Reject with feedback on the InfoBar and the feedback box open](images/diff-reject.png)
+
+One deliberate exception (1.14.4): writes to Claude's **own working files** - its `~/.claude` memory and config, temp-dir scratch files, and the workspace's `.claude/` internals - skip the gate entirely (each one is logged in the activity feed), so a session never stalls on reviewing its own scaffolding. Project code, both new files and edits to existing ones, always gets the diff.
 
 You have three choices on the InfoBar:
 

--- a/docs/marketplace.md
+++ b/docs/marketplace.md
@@ -123,6 +123,8 @@ A dockable Claude Code panel shows connection status, edit decisions, and token 
 - **From here:** click **Download** or **Install**, or in Visual Studio open **Extensions > Manage Extensions** and search for *Claude Code for Visual Studio*.
 - **Sideload:** download the `.vsix` from [GitHub Releases](https://github.com/firish/claude_code_vs/releases) and double-click it.
 
+After installing, everything lives in one dockable panel: **View > Other Windows > Claude Code**.
+
 ## Quickstart
 
 1. Open your project or solution in Visual Studio 2026.

--- a/src/ClaudeCodeVS/BridgeHost.cs
+++ b/src/ClaudeCodeVS/BridgeHost.cs
@@ -89,7 +89,27 @@ internal sealed class BridgeHost : IDisposable
         {
             Ui.BridgeStatus.SetConnected(connected);
             WatchMcpLoad(connected); // arm/stand-down the "PULL tools didn't load" detector
-            if (connected) return;
+            if (connected)
+            {
+                // Install-on-connect (marketplace feedback): a session that reaches the bridge without
+                // going through our Launch button (manual `claude` + /ide, a fresh clone whose committed
+                // settings.json references our hooks) used to hit "-File does not exist" on every prompt
+                // because the scripts were never materialized. Idempotent; runs off-thread.
+                _ = Task.Run(async () =>
+                {
+                    try
+                    {
+                        var ws = await GetWorkspaceRootAsync();
+                        if (!string.IsNullOrEmpty(ws))
+                        {
+                            Hooks.PermissionHookInstaller.EnsureInstalled(ws!);
+                            Hooks.McpInstaller.EnsureInstalled(ws!);
+                        }
+                    }
+                    catch (Exception e) { Log.Warn($"install-on-connect failed: {e.Message}"); }
+                });
+                return;
+            }
 #pragma warning disable VSSDK007
             ThreadHelper.JoinableTaskFactory.RunAsync(async () =>
             {
@@ -167,6 +187,17 @@ internal sealed class BridgeHost : IDisposable
     /// </summary>
     private async Task<(bool allow, string? reason)> ShowPermissionDiffAsync(string filePath, string newContents, CancellationToken ct)
     {
+        // Selective gate (marketplace feedback): the CLI's own working files - its ~/.claude
+        // memory/config tree, temp-dir scratch files, and the workspace's .claude/ internals - skip the
+        // diff entirely, so a session scaffolding scratch code or writing memory never stalls on review.
+        // PROJECT CODE stays gated: every create or edit under the workspace (outside .claude/) still
+        // opens the diff.
+        if (IsScratchOrMemoryPath(filePath, Ui.BridgeStatus.Workspace))
+        {
+            Log.Info($"scratch/memory write auto-allowed (not project code): {filePath}");
+            return (true, null);
+        }
+
         // Run-wild: when auto-accept is on, allow immediately without opening the diff.
         if (Ui.BridgeStatus.AutoAcceptEdits)
         {
@@ -199,6 +230,33 @@ internal sealed class BridgeHost : IDisposable
         if (d.Accepted)
             ScheduleReload(filePath);
         return (d.Accepted, d.RejectReason);
+    }
+
+    /// <summary>
+    /// True for the CLI's own working areas, which the edit gate skips: the user-level ~/.claude tree
+    /// (auto-memory, config), anything under the machine temp dir (the CLI's scratchpad lives there),
+    /// and the workspace's .claude/ subtree (our scripts, attachments, CLI settings). Deliberately NOT
+    /// path-pattern guessing beyond that - a "scratch/" folder inside the repo is still project code.
+    /// </summary>
+    private static bool IsScratchOrMemoryPath(string filePath, string? workspace)
+    {
+        try
+        {
+            var full = System.IO.Path.GetFullPath(filePath);
+            bool Under(string root) =>
+                !string.IsNullOrEmpty(root) &&
+                full.StartsWith(root.TrimEnd('\\', '/') + System.IO.Path.DirectorySeparatorChar, StringComparison.OrdinalIgnoreCase);
+
+            var home = Environment.GetFolderPath(Environment.SpecialFolder.UserProfile);
+            if (Under(System.IO.Path.Combine(home, ".claude"))) return true;
+            if (Under(System.IO.Path.GetTempPath())) return true;
+            if (!string.IsNullOrEmpty(workspace) && Under(System.IO.Path.Combine(workspace!, ".claude"))) return true;
+            return false;
+        }
+        catch
+        {
+            return false; // unparseable path -> gate it (fail toward review)
+        }
     }
 
     /// <summary>

--- a/src/ClaudeCodeVS/Hooks/PermissionHookInstaller.cs
+++ b/src/ClaudeCodeVS/Hooks/PermissionHookInstaller.cs
@@ -27,8 +27,18 @@ internal static class PermissionHookInstaller
     private const int DebugTimeoutSeconds = 10;
     private const int NotifyTimeoutSeconds = 10;
 
+    /// <summary>
+    /// The registered hook command. Test-Path-guarded (marketplace feedback): the scripts live in the
+    /// workspace's .claude/ and the path is cwd-relative, so a session started in a subfolder - or a
+    /// checkout that has settings.json but not the scripts - used to spam "-File does not exist" errors
+    /// on every prompt. Guarded, a missing script is a silent no-op (exit 0) and the CLI's own behavior
+    /// takes over; install-on-connect (BridgeHost) is the other half, materializing the scripts for any
+    /// session that reaches the bridge. Stdin flows through to the script, and its exit code/stdout are
+    /// preserved, so hook semantics are unchanged when the script IS present.
+    /// </summary>
     private static string Command(string script) =>
-        $"powershell -NoProfile -ExecutionPolicy Bypass -File .claude/{script}";
+        "powershell -NoProfile -ExecutionPolicy Bypass -Command "
+        + $"\"if (Test-Path '.claude/{script}') {{ & '.claude/{script}' }} else {{ exit 0 }}\"";
 
     public static void EnsureInstalled(string workspaceRoot)
     {
@@ -82,7 +92,7 @@ internal static class PermissionHookInstaller
             }
 
             File.WriteAllText(settingsPath, root.ToString(Formatting.Indented));
-            Log.Info($"hooks: updated {settingsPath} (PreToolUse {(addedPre ? "ADDED" : "present")}, Stop {(addedStop ? "ADDED" : "present")}, UserPromptSubmit {(addedDebug ? "ADDED" : "present")}, Notification {(addedNotify ? "ADDED" : "present")})");
+            Log.Info($"hooks: updated {settingsPath} (PreToolUse {(addedPre ? "added/updated" : "present")}, Stop {(addedStop ? "added/updated" : "present")}, UserPromptSubmit {(addedDebug ? "added/updated" : "present")}, Notification {(addedNotify ? "added/updated" : "present")})");
         }
         catch (Exception e)
         {
@@ -90,7 +100,11 @@ internal static class PermissionHookInstaller
         }
     }
 
-    /// <summary>Add a hook for <paramref name="eventName"/> pointing at <paramref name="script"/> if not already present. Returns true if it changed settings.</summary>
+    /// <summary>
+    /// Add a hook for <paramref name="eventName"/> pointing at <paramref name="script"/>, or MIGRATE an
+    /// existing entry whose command drifted from the current form (e.g. the pre-1.14.4 unguarded
+    /// "-File .claude/x.ps1" shape). Returns true if it changed settings.
+    /// </summary>
     private static bool EnsureHook(JObject hooks, string eventName, string? matcher, string script, int timeoutSeconds)
     {
         // Same clone-on-reparent hazard as above: keep the existing array in place, only assign a new one.
@@ -99,7 +113,17 @@ internal static class PermissionHookInstaller
             arr = new JArray();
             hooks[eventName] = arr;
         }
-        if (AlreadyInstalled(arr, script)) return false;
+
+        var existing = FindOurHook(arr, script);
+        if (existing != null)
+        {
+            var want = Command(script);
+            if (string.Equals((string?)existing["command"], want, StringComparison.Ordinal)) return false;
+            // Migrate IN PLACE: setting a value property on the EXISTING object is safe - it's
+            // re-parenting a token into a new parent that clones (the 1.11.0 lesson), not this.
+            existing["command"] = want;
+            return true;
+        }
 
         var entry = new JObject
         {
@@ -116,7 +140,9 @@ internal static class PermissionHookInstaller
         return true;
     }
 
-    private static bool AlreadyInstalled(JArray eventHooks, string script)
+    /// <summary>The inner hook object whose command references our script, or null. Match is by script
+    /// name so every historical command shape (old -File form, new guarded form) is found and owned.</summary>
+    private static JObject? FindOurHook(JArray eventHooks, string script)
     {
         foreach (var entry in eventHooks.OfType<JObject>())
         {
@@ -125,10 +151,10 @@ internal static class PermissionHookInstaller
             {
                 var cmd = (string?)h["command"];
                 if (cmd != null && cmd.IndexOf(script, StringComparison.OrdinalIgnoreCase) >= 0)
-                    return true;
+                    return h;
             }
         }
-        return false;
+        return null;
     }
 
     private static string ReadEmbeddedScript(string scriptFileName)

--- a/src/ClaudeCodeVS/source.extension.vsixmanifest
+++ b/src/ClaudeCodeVS/source.extension.vsixmanifest
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="utf-8"?>
 <PackageManifest Version="2.0.0" xmlns="http://schemas.microsoft.com/developer/vsx-schema/2011" xmlns:d="http://schemas.microsoft.com/developer/vsx-schema-design/2011">
   <Metadata>
-    <Identity Id="ClaudeCodeVS.d9032717-8a83-4ab5-9b63-2fe9d9a78481" Version="1.14.3" Language="en-US" Publisher="Rishi Gulati" />
+    <Identity Id="ClaudeCodeVS.d9032717-8a83-4ab5-9b63-2fe9d9a78481" Version="1.14.4" Language="en-US" Publisher="Rishi Gulati" />
     <DisplayName>Claude Code for Visual Studio</DisplayName>
     <Description xml:space="preserve">Bring Claude Code into Visual Studio: a native diff window with accept/reject (and reject-with-feedback), automatic selection and C#/C++ compiler-diagnostics context, live debugger access (Claude reads your runtime state and can opt-in drive the debugger), Roslyn code navigation with decompile, a test runner that catches flaky tests under the debugger, finished/needs-input notifications, and a token/cost panel. The claude CLI does the agent work; this extension is the IDE half of Claude Code's integration protocol. Requires the Claude Code CLI. Unofficial, not affiliated with Anthropic.</Description>
     <MoreInfo>https://github.com/firish/claude_code_vs</MoreInfo>


### PR DESCRIPTION
﻿fix: marketplace-review fixes - selective edit gate, hook-script resilience, docs discoverability (1.14.4)

Three fixes straight from a Marketplace review.

1. Selective diff gate: the CLI's OWN working files - its ~/.claude memory and
   config tree, temp-dir scratch files, and the workspace's .claude/ internals
   - skip the diff entirely (feed-logged per skip), so a session scaffolding
   scratch code or writing memory never stalls on review. PROJECT CODE is
   unchanged: every create or edit under the workspace (outside .claude/)
   still opens the diff. Deliberately no path-pattern guessing beyond those
   three roots - a scratch/ folder inside the repo is still project code.
   Unparseable paths fail toward review.

2. "-File does not exist" hook-error spam, two halves:
   - install-on-connect: EnsureInstalled now also runs when a CLI session
     connects to the bridge, not only via the Launch button - covers manual
     `claude` + /ide and fresh clones whose committed settings.json references
     our hooks but whose scripts were never materialized;
   - Test-Path-guarded hook commands: the registered command is now
     powershell -Command "if (Test-Path '.claude/x.ps1') { & '...' } else
     { exit 0 }", so a genuinely missing script (cwd mismatch, partial
     checkout) is a silent no-op with the CLI's own behavior taking over.
     Stdin, stdout, and exit codes flow through unchanged when the script is
     present. EnsureHook now MIGRATES existing entries to the current command
     form in place (property assignment on the existing JObject - no
     clone-on-reparent hazard).

3. Docs discoverability: GETTING-STARTED and the README/marketplace Install
   sections now lead with "View > Other Windows > Claude Code" - it was
   documented but buried mid-quickstart.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

