### PR TITLE
Restore the native VS terminal on VS 18.9 (SVsTerminalService route)

### DIFF
--- a/src/ClaudeCodeVS/Terminal/VsTerminalLauncher.cs
+++ b/src/ClaudeCodeVS/Terminal/VsTerminalLauncher.cs
@@ -67,10 +67,9 @@ internal static class VsTerminalLauncher
         try
         {
             var terminalServiceType = FindType("Microsoft.VisualStudio.Terminal.ITerminalService");
-            var descriptorsType = FindType("Microsoft.VisualStudio.Terminal.TerminalServiceDescriptors");
             var windowOptionsType = FindType("Microsoft.VisualStudio.Terminal.TerminalWindowOptions");
             var profileConfigType = FindType("Microsoft.VisualStudio.Terminal.ProfileConfig");
-            if (terminalServiceType == null || descriptorsType == null || profileConfigType == null)
+            if (terminalServiceType == null || profileConfigType == null)
             {
                 Log.Warn("Native VS terminal: Microsoft.VisualStudio.Terminal types not found (VS edition/version mismatch) - falling back to external console.");
                 return false;
@@ -79,54 +78,28 @@ internal static class VsTerminalLauncher
             // VS 2022 (17.x) contract, where CreateTerminalAsync takes name/profile/cwd as plain args
             // (issue #12 follow-up: same service, older shape - dumped headlessly from 17.14's DLL).
 
-            var descriptor = descriptorsType
-                .GetProperty("TerminalServiceDescriptor", BindingFlags.Public | BindingFlags.Static)?
-                .GetValue(null) as ServiceRpcDescriptor;
-            if (descriptor == null)
-            {
-                Log.Warn("Native VS terminal: TerminalServiceDescriptor missing - falling back to external console.");
-                return false;
-            }
-
             await ThreadHelper.JoinableTaskFactory.SwitchToMainThreadAsync(ct);
-            var containerObj = await AsyncServiceProvider.GlobalProvider.GetServiceAsync(typeof(SVsBrokeredServiceContainer));
-            if (containerObj is not IBrokeredServiceContainer container)
-            {
-                Log.Warn("Native VS terminal: SVsBrokeredServiceContainer unavailable - falling back to external console.");
-                return false;
-            }
-            IServiceBroker broker = container.GetFullAccessServiceBroker();
-            // GetServiceAsync above takes NO token, and on a cold ServiceHub it can stall long past our
-            // timeout - after which the fallback has already launched the external console. Explicit
-            // gates from here down keep a late-running attempt from opening a SECOND terminal (seen
-            // live 2026-08-06: 10s stall -> external console AND a late native tab, two sessions).
+            // The acquisition below can stall long past our timeout on a cold ServiceHub - after which
+            // the fallback has already launched the external console. Explicit gates from here down keep
+            // a late-running attempt from opening a SECOND terminal (seen live 2026-08-06: 10s stall ->
+            // external console AND a late native tab, two sessions).
             ct.ThrowIfCancellationRequested();
 
-            // T = ITerminalService is only known as a reflected Type, so the generic call needs
-            // MakeGenericMethod. Overload-tolerant lookup: a bare GetMethod("GetProxyAsync") throws
-            // AmbiguousMatchException the moment a ServiceHub.Framework servicing update adds an
-            // overload - issue #12, seen on VS2022 AND VS2026 (the assembly ships to both). Select the
-            // exact shape we call instead.
-            var getProxyOpen = PickMethod(typeof(IServiceBroker), "GetProxyAsync", m =>
-            {
-                if (!m.IsGenericMethodDefinition) return false;
-                var p = m.GetParameters();
-                return p.Length == 3
-                    && typeof(ServiceRpcDescriptor).IsAssignableFrom(p[0].ParameterType)
-                    && p[1].ParameterType == typeof(ServiceActivationOptions)
-                    && p[2].ParameterType == typeof(CancellationToken);
-            });
-            if (getProxyOpen == null)
-            {
-                Log.Warn("Native VS terminal: no compatible IServiceBroker.GetProxyAsync overload - falling back to external console.");
-                return false;
-            }
-            var getProxy = getProxyOpen.MakeGenericMethod(terminalServiceType);
-            object? terminalService = await UnwrapAsync(
-                getProxy.Invoke(broker, new object?[] { descriptor, default(ServiceActivationOptions), ct }));
+            // TWO acquisition routes, newest first. VS 18.9 (18.9.12105.275, 2026-08-12) REMOVED
+            // TerminalServiceDescriptors and moved the terminal off the brokered-service bus onto a
+            // classic VS service: SVsTerminalService -> IVsTerminalService.CreateTerminalService().
+            // Older VS - including every 17.x - only has the brokered descriptor. ITerminalService
+            // itself is unchanged on both, so everything downstream of here is shared.
+            bool viaBroker = false;
+            object? terminalService = await TryGetViaVsServiceAsync(ct);
             if (terminalService == null)
             {
-                Log.Warn("Native VS terminal: GetProxyAsync<ITerminalService> returned null - falling back to external console.");
+                terminalService = await TryGetViaBrokerAsync(terminalServiceType, ct);
+                viaBroker = terminalService != null;
+            }
+            if (terminalService == null)
+            {
+                Log.Warn("Native VS terminal: could not acquire ITerminalService via SVsTerminalService (18.9+) or the brokered descriptor (older) - falling back to external console.");
                 return false;
             }
 
@@ -240,8 +213,10 @@ internal static class VsTerminalLauncher
                 }
                 catch { /* best-effort cleanup; the profile cache is cosmetic */ }
 
-                // Brokered-service proxies must be disposed - each GetProxyAsync hands out a live RPC client.
-                (terminalService as IDisposable)?.Dispose();
+                // Brokered-service proxies must be disposed - each GetProxyAsync hands out a live RPC
+                // client. The 18.9+ SVsTerminalService route hands back a service the SHELL owns, so
+                // disposing that one would tear down state we don't own.
+                if (viaBroker) (terminalService as IDisposable)?.Dispose();
             }
         }
         catch (OperationCanceledException)
@@ -255,6 +230,88 @@ internal static class VsTerminalLauncher
         {
             Log.Warn($"Native VS terminal launch failed ({e.GetType().Name}: {e.Message}) - falling back to external console.");
             return false;
+        }
+    }
+
+    /// <summary>
+    /// VS 18.9+ route: the terminal is a classic VS service again. Both the service marker
+    /// (SVsTerminalService) and the interface (IVsTerminalService, whose sole member is
+    /// ITerminalService CreateTerminalService()) live in the reflection-loaded assembly, so the whole
+    /// hop is reflection - we can't name either type at compile time. Returns null (not throws) on any
+    /// miss so the caller can try the older brokered route.
+    /// </summary>
+    private static async Task<object?> TryGetViaVsServiceAsync(CancellationToken ct)
+    {
+        try
+        {
+            var markerType = FindType("Microsoft.VisualStudio.Terminal.SVsTerminalService");
+            var vsServiceType = FindType("Microsoft.VisualStudio.Terminal.IVsTerminalService");
+            if (markerType == null || vsServiceType == null) return null;
+
+            await ThreadHelper.JoinableTaskFactory.SwitchToMainThreadAsync(ct);
+            object? svc = await AsyncServiceProvider.GlobalProvider.GetServiceAsync(markerType);
+            if (svc == null) return null;
+            ct.ThrowIfCancellationRequested();
+
+            return PickMethod(vsServiceType, "CreateTerminalService", m => m.GetParameters().Length == 0)?
+                .Invoke(svc, null);
+        }
+        catch (OperationCanceledException) { throw; }
+        catch (Exception e)
+        {
+            Log.Warn($"Native VS terminal: SVsTerminalService route unavailable ({e.GetType().Name}: {e.Message}) - trying the brokered route.");
+            return null;
+        }
+    }
+
+    /// <summary>
+    /// Pre-18.9 route: ITerminalService came off the brokered-service bus, addressed by the static
+    /// TerminalServiceDescriptors.TerminalServiceDescriptor. VS 18.9 deleted that type outright, so
+    /// this is now the VS 2022 (17.x) / older-18.x path only. Returns null (not throws) on any miss.
+    /// </summary>
+    private static async Task<object?> TryGetViaBrokerAsync(Type terminalServiceType, CancellationToken ct)
+    {
+        try
+        {
+            var descriptorsType = FindType("Microsoft.VisualStudio.Terminal.TerminalServiceDescriptors");
+            var descriptor = descriptorsType?
+                .GetProperty("TerminalServiceDescriptor", BindingFlags.Public | BindingFlags.Static)?
+                .GetValue(null) as ServiceRpcDescriptor;
+            if (descriptor == null) return null;
+
+            await ThreadHelper.JoinableTaskFactory.SwitchToMainThreadAsync(ct);
+            var containerObj = await AsyncServiceProvider.GlobalProvider.GetServiceAsync(typeof(SVsBrokeredServiceContainer));
+            if (containerObj is not IBrokeredServiceContainer container) return null;
+            IServiceBroker broker = container.GetFullAccessServiceBroker();
+            // GetServiceAsync above takes NO token and can stall on a cold ServiceHub; gate before the
+            // proxy handout so a late completion never opens a terminal the fallback already replaced.
+            ct.ThrowIfCancellationRequested();
+
+            // T = ITerminalService is only known as a reflected Type, so the generic call needs
+            // MakeGenericMethod. Overload-tolerant lookup: a bare GetMethod("GetProxyAsync") throws
+            // AmbiguousMatchException the moment a ServiceHub.Framework servicing update adds an
+            // overload - issue #12, seen on VS2022 AND VS2026 (the assembly ships to both). Select the
+            // exact shape we call instead.
+            var getProxyOpen = PickMethod(typeof(IServiceBroker), "GetProxyAsync", m =>
+            {
+                if (!m.IsGenericMethodDefinition) return false;
+                var p = m.GetParameters();
+                return p.Length == 3
+                    && typeof(ServiceRpcDescriptor).IsAssignableFrom(p[0].ParameterType)
+                    && p[1].ParameterType == typeof(ServiceActivationOptions)
+                    && p[2].ParameterType == typeof(CancellationToken);
+            });
+            if (getProxyOpen == null) return null;
+
+            var getProxy = getProxyOpen.MakeGenericMethod(terminalServiceType);
+            return await UnwrapAsync(
+                getProxy.Invoke(broker, new object?[] { descriptor, default(ServiceActivationOptions), ct }));
+        }
+        catch (OperationCanceledException) { throw; }
+        catch (Exception e)
+        {
+            Log.Warn($"Native VS terminal: brokered route unavailable ({e.GetType().Name}: {e.Message}).");
+            return null;
         }
     }
 


### PR DESCRIPTION
## The problem

VS **18.9** (`18.9.12105.275`, shipped 2026-08-12) removed `Microsoft.VisualStudio.Terminal.TerminalServiceDescriptors` and moved the terminal off the brokered-service bus onto a classic VS service.

`VsTerminalLauncher` addressed `ITerminalService` **only** through that descriptor, and bailed as soon as the type was missing:

```csharp
if (terminalServiceType == null || descriptorsType == null || profileConfigType == null)
{
    Log.Warn("Native VS terminal: Microsoft.VisualStudio.Terminal types not found ...");
    return false;
}
```

So on 18.9 **every Launch silently takes the external-console fallback** — the docked "Claude Code" terminal tab is simply gone. The fallback works, so nothing is broken loudly; the feature just quietly disappears. This is exactly the fragility `CLAUDE.md` flags about this reflection-loaded, undocumented surface.

## What changed

Only the **acquisition hop**. `ITerminalService` itself is unchanged on 18.9 — same `CreateTerminalWindowAsync(ct, TerminalWindowOptions)` and the 17.x `CreateTerminalAsync` overloads — so everything downstream (ProfileConfig, `AddCachedProfile`, the create call, `RemoveCachedProfile`) is untouched and shared.

Two routes, newest first:

| Route | VS | How |
|---|---|---|
| `TryGetViaVsServiceAsync` | 18.9+ | `SVsTerminalService` → `IVsTerminalService.CreateTerminalService()` |
| `TryGetViaBrokerAsync` | 17.x / older 18.x | `TerminalServiceDescriptors.TerminalServiceDescriptor` + `IServiceBroker.GetProxyAsync<ITerminalService>` (moved as-is) |

The brokered route is kept because it is still the **only** route on VS 2022, and the manifest supports `[17.14, 19.0)`. Both return `null` rather than throwing, so a miss falls through to the next route and finally to the external console — the existing safety net is preserved end to end.

Two details worth calling out:

- **The whole 18.9 hop is reflection.** `SVsTerminalService` and `IVsTerminalService` both live in the reflection-loaded `Microsoft.VisualStudio.Terminal.dll`, so neither type can be named at compile time — same constraint as the existing code, and the `.vsix` still ships zero of its DLLs.
- **Dispose is now conditional.** The brokered route hands out a live RPC proxy that must be disposed; the 18.9 route returns a service the **shell** owns, so disposing it would tear down state we don't own.

## How the API shape was determined

Dumped headlessly from the shipped assembly before writing any in-proc reflection (the practice `CLAUDE.md` prescribes), rather than guessing:

```
### Microsoft.VisualStudio.Terminal.IVsTerminalService
      ITerminalService CreateTerminalService()

### Microsoft.VisualStudio.Terminal.ITerminalService
      Task`1 CreateTerminalWindowAsync(CancellationToken cancellationToken, TerminalWindowOptions options)
      Task`1 CreateTerminalAsync(CancellationToken cancellationToken, String name, ProfileConfig profile, String workingDirectory)
      ...
```

`TerminalServiceDescriptors` returns `NOT FOUND` on 18.9, while `ITerminalService`, `TerminalWindowOptions` and `ProfileConfig` are all still present — which is why the guard, not the downstream calls, was the thing that needed changing.

## Verification

Release build clean (pre-existing nullable warnings aside), and **tested live on 18.9.12105.275**, not just compiled:

| | Before the fix | After |
|---|---|---|
| Spawned process | `"cmd.exe" /K claude` | `cmd.exe /K set ENABLE_IDE_INTEGRATION=true&&set CLAUDE_CODE_SSE_PORT=…&&claude` |
| Parent | `devenv.exe` | the terminal-service host |
| External console window | yes | **none** |
| Panel feed | `Native VS terminal: … types not found` | launches into the native window |

The "Claude Code" tab now opens docked in VS's terminal window, alongside the Developer PowerShell tabs, with the CLI running inside it.

Not verified on VS 2022 (no 17.x install here) — that path is byte-for-byte the previous code, just moved into its own method, so it should be unaffected.

## Scope

Single file, no overlap with #25 or #26 (neither touches `VsTerminalLauncher.cs`). Branched from a clean `origin/main`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
