### PR TITLE
Wrap the attach row so Compose stays reachable in a narrow panel

### DIFF
--- a/src/ClaudeCodeVS/Ui/ClaudeToolWindowControl.cs
+++ b/src/ClaudeCodeVS/Ui/ClaudeToolWindowControl.cs
@@ -253,7 +253,11 @@ internal sealed class ClaudeToolWindowControl : UserControl
             Opacity = 0.75,
             VerticalAlignment = VerticalAlignment.Center,
         }, 0.96);
-        var attachHeader = new StackPanel { Orientation = Orientation.Horizontal };
+        // WrapPanel, not a horizontal StackPanel, for the same reason as the toolbar above: at a docked
+        // panel width the hint plus Paste/Compose/Clear overflow, and a StackPanel just runs off the edge
+        // (the card grew a horizontal scrollbar and Compose sat half outside it). Wrapping keeps each
+        // button whole and clickable at any width.
+        var attachHeader = new WrapPanel();
         attachHeader.Children.Add(attachHint);
         var pasteBtn = MakeButton(Strings.BtnPaste, PasteFromClipboard);
         pasteBtn.Margin = new Thickness(6, 0, 6, 0);


### PR DESCRIPTION
Follow-up to #25, found while checking the 1.19.0 panel in the experimental hive.

## The problem

#25 gave the toolbar a `WrapPanel`, but the attach card's header row was still a horizontal `StackPanel`. At a docked/narrow panel width the hint text plus `Paste` / `Compose` / `Clear` overflow the card: the panel grows a horizontal scrollbar and `Compose` sits half outside the visible area. The button is technically there, but you have to scroll sideways to click it — which is not obvious, since nothing else in the panel scrolls horizontally.

I hit it on a plain right-docked panel at 1.19.0, so it is not an exotic width.

## The fix

One line: swap the `StackPanel` for a `WrapPanel`, the same treatment and for the same reason as the toolbar above it. No new types, no layout restructuring, no resource strings — the existing margins already give the wrapped row the spacing the toolbar uses.

## Verified

Release build clean; the `.vsix` still ships zero Roslyn/TestWindow DLLs and keeps `zh-Hans/ClaudeCodeVS.resources.dll`.

Ran it in the experimental hive on 18.9.12105.275 (VS 2026), panel floating so I could drive the width directly:

- **360 px wide** — the hint stays on line 1, `Paste` and `Compose` wrap to line 2, both fully visible and inside the card. Before the change, `Compose` was cut by the card edge at this width.
- **620 px wide** — unchanged from before: hint, `Paste` and `Compose` all on one line. No gratuitous wrapping when there is room.

The horizontal scrollbar still visible at the bottom of the panel belongs to the ACTIVITY feed (long log lines, deliberately not wrapped) — that one is pre-existing and correct.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
